### PR TITLE
Add waifu2x model

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ We've put up the largest collection of machine learning models that work with Ap
 * **The Scream** - Transfer a color image into The-Scream style. [Download](https://s3-us-west-2.amazonaws.com/coreml-models/FNS-The-Scream.mlmodel) | [Demo](https://github.com/prisma-ai/torch2coreml) | [Reference](http://cs.stanford.edu/people/jcjohns/eccv16/)
 * **Udnie** - Transfer a color image into Udnie style. [Download](https://s3-us-west-2.amazonaws.com/coreml-models/FNS-Udnie.mlmodel) | [Demo](https://github.com/prisma-ai/torch2coreml) | [Reference](http://cs.stanford.edu/people/jcjohns/eccv16/)
 * **Mosaic** - Transfer a color image into Mosaic style. [Download](https://s3-us-west-2.amazonaws.com/coreml-models/FNS-Mosaic.mlmodel) | [Demo](https://github.com/prisma-ai/torch2coreml) | [Reference](http://cs.stanford.edu/people/jcjohns/eccv16/)
+* **Waifu2x** - Scale and denoise anime-style artworks. [Download](https://github.com/imxieyi/waifu2x-ios/raw/master/models/anime_scale2x_model.mlmodel) | [Demo](https://github.com/imxieyi/waifu2x-ios) | [Reference](https://arxiv.org/abs/1501.00092)
 
 ## Text Analysis
 *Models that takes text data as input and output useful information about the text.*


### PR DESCRIPTION
I added the [waifu2x-ios](https://github.com/imxieyi/waifu2x-ios) project.


## Model URL
https://github.com/imxieyi/waifu2x-ios/raw/master/models/anime_scale2x_model.mlmodel

## Demo URL
https://github.com/imxieyi/waifu2x-ios

## Descriptions
It can make a bicubic-scaled anime-style artwork look more sharply.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Only one item is in this pull request
- [x] The model info contains all the required fields
- [x] The demo project is compilable
- [x] Has proper reference
