### PR TITLE
Add BERT for Question answering

### DIFF
--- a/content.json
+++ b/content.json
@@ -250,6 +250,14 @@
                "demo_link": "https://github.com/novinfard/profiler-sentiment-analysis/",
                "reference_link": "https://github.com/novinfard/profiler-sentiment-analysis/blob/master/dissertation-v6.pdf",
                "type": "text"
+               },
+                              {
+               "name": "BERT for Question answering",
+               "description": "Swift Core ML 3 implementation of BERT for Question answering",
+               "download_link": "https://github.com/huggingface/swift-coreml-transformers/blob/master/Resources/BERTSQUADFP16.mlmodel",
+               "demo_link": "https://github.com/huggingface/swift-coreml-transformers",
+               "reference_link": "https://github.com/huggingface/pytorch-pretrained-BERT",
+               "type": "text"
                }
     ]
 }


### PR DESCRIPTION
Swift Core ML 3 implementation of BERT for Question answering

## Model URL
https://github.com/huggingface/swift-coreml-transformers/blob/master/Resources/BERTSQUADFP16.mlmodel

## Demo URL
https://github.com/huggingface/swift-coreml-transformers

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Only one item is in this pull request
- [x] The model info contains all the required fields
- [x] The demo project is compilable
- [x] Has proper reference
