### PR TITLE
Adding image segmentation and depth prediction model repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ Recently, we've included visualization tools. And here's one [Netron](https://lu
 * **Nudity** - Classifies an image either as NSFW (nude) or SFW (not nude)
  [Download](https://drive.google.com/open?id=0B5TjkH3njRqncDJpdDB1Tkl2S2s) | [Demo](https://github.com/ph1ps/Nudity-CoreML) | [Reference](https://github.com/yahoo/open_nsfw)
 * **TextRecognition (ML Kit)** - Recognizing text using ML Kit built-in model in real-time. [Download]() | [Demo](https://github.com/tucan9389/TextRecognition-MLKit) | [Reference](https://firebase.google.com/docs/ml-kit/ios/recognize-text)
-
+* **ImageSegmentation** - Segment the pixels of a camera frame or image into a predefined set of classes. [Download](https://developer.apple.com/machine-learning/models/) | [Demo](https://github.com/tucan9389/ImageSegmentation-CoreML) | [Reference](https://github.com/tensorflow/models/tree/master/research/deeplab)
 
 ## Image - Image
 *Models that transform image.*
@@ -108,4 +108,3 @@ Recently, we've included visualization tools. And here's one [Netron](https://lu
 # Contributing and License
 * [See the guide](https://github.com/likedan/Awesome-CoreML-Models/blob/master/.github/CONTRIBUTING.md)
 * Distributed under the MIT license. See LICENSE for more information.
-

--- a/content.json
+++ b/content.json
@@ -269,14 +269,22 @@
                   "demo_link": "https://github.com/tucan9389/TextRecognition-MLKit",
                   "reference_link": "https://firebase.google.com/docs/ml-kit/ios/recognize-text",
                   "type": "image"
-            }
-                 {
+            },
+            {
                   "name": "ESC-10",
                   "description": "Recognize sounds from the ESC-10 sound dataset.",
                   "download_link": (https://github.com/narner/ESC10-CoreML/blob/master/CreateML%20Project%20And%20Dataset/ESC-10%20Sound%20Classifier.mlproj/Models/ESC-10%20Sound%20Classifier.mlmodel),
                   "demo_link": "https://github.com/narner/ESC10-CoreML/tree/master/ECS10-CoreML-Demo",
                   "reference_link": "https://nicholas-arner.squarespace.com/blog/2019/10/29/classification-of-sound-files-on-ios-with-the-soundanalysis-framework",
                   "type": "miscellaneous"
+            },
+            {
+                  "name": "ImageSegmentation",
+                  "description": "Segment the pixels of a camera frame or image into a predefined set of classes.",
+                  "download_link": (https://developer.apple.com/machine-learning/models/),
+                  "demo_link": "https://github.com/tucan9389/ImageSegmentation-CoreML",
+                  "reference_link": "https://github.com/tensorflow/models/tree/master/research/deeplab",
+                  "type": "image"
             }
       ]
 }


### PR DESCRIPTION
## Model URL

https://developer.apple.com/machine-learning/models/

## Demo URL

https://github.com/tucan9389/ImageSegmentation-CoreML

| screenshot 1 | screenshot 2 | screenshot 3 |
| ---- | ---- | ---- |
| <img src="https://github.com/tucan9389/ImageSegmentation-CoreML/raw/master/resource/IMG_3632.PNG"> | <img src="https://github.com/tucan9389/ImageSegmentation-CoreML/raw/master/resource/IMG_3633.PNG"> | <img src="https://github.com/tucan9389/ImageSegmentation-CoreML/raw/master/resource/IMG_3634.PNG"> |

## Descriptions

Segment the pixels of a camera frame or image into a predefined set of classes.

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Only one item is in this pull request
- [x] The model info contains all the required fields
- [x] The demo project is compilable
- [x] Has proper reference
