### PR TITLE
Adding image depth prediction model repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Recently, we've included visualization tools. And here's one [Netron](https://lu
  [Download](https://drive.google.com/open?id=0B5TjkH3njRqncDJpdDB1Tkl2S2s) | [Demo](https://github.com/ph1ps/Nudity-CoreML) | [Reference](https://github.com/yahoo/open_nsfw)
 * **TextRecognition (ML Kit)** - Recognizing text using ML Kit built-in model in real-time. [Download]() | [Demo](https://github.com/tucan9389/TextRecognition-MLKit) | [Reference](https://firebase.google.com/docs/ml-kit/ios/recognize-text)
 * **ImageSegmentation** - Segment the pixels of a camera frame or image into a predefined set of classes. [Download](https://developer.apple.com/machine-learning/models/) | [Demo](https://github.com/tucan9389/ImageSegmentation-CoreML) | [Reference](https://github.com/tensorflow/models/tree/master/research/deeplab)
+* **DepthPrediction** - Predict the depth from a single image. [Download](https://developer.apple.com/machine-learning/models/) | [Demo](https://github.com/tucan9389/DepthPrediction-CoreML) | [Reference](https://github.com/iro-cp/FCRN-DepthPrediction)
 
 ## Image - Image
 *Models that transform image.*

--- a/content.json
+++ b/content.json
@@ -285,6 +285,14 @@
                   "demo_link": "https://github.com/tucan9389/ImageSegmentation-CoreML",
                   "reference_link": "https://github.com/tensorflow/models/tree/master/research/deeplab",
                   "type": "image"
+            },
+            {
+                  "name": "DepthPrediction",
+                  "description": "Predict the depth from a single image.",
+                  "download_link": (https://developer.apple.com/machine-learning/models/),
+                  "demo_link": "https://github.com/tucan9389/DepthPrediction-CoreML",
+                  "reference_link": "https://github.com/iro-cp/FCRN-DepthPrediction",
+                  "type": "image"
             }
       ]
 }

--- a/content.json
+++ b/content.json
@@ -273,7 +273,7 @@
             {
                   "name": "ESC-10",
                   "description": "Recognize sounds from the ESC-10 sound dataset.",
-                  "download_link": (https://github.com/narner/ESC10-CoreML/blob/master/CreateML%20Project%20And%20Dataset/ESC-10%20Sound%20Classifier.mlproj/Models/ESC-10%20Sound%20Classifier.mlmodel),
+                  "download_link": "https://github.com/narner/ESC10-CoreML/blob/master/CreateML%20Project%20And%20Dataset/ESC-10%20Sound%20Classifier.mlproj/Models/ESC-10%20Sound%20Classifier.mlmodel",
                   "demo_link": "https://github.com/narner/ESC10-CoreML/tree/master/ECS10-CoreML-Demo",
                   "reference_link": "https://nicholas-arner.squarespace.com/blog/2019/10/29/classification-of-sound-files-on-ios-with-the-soundanalysis-framework",
                   "type": "miscellaneous"
@@ -281,7 +281,7 @@
             {
                   "name": "ImageSegmentation",
                   "description": "Segment the pixels of a camera frame or image into a predefined set of classes.",
-                  "download_link": (https://developer.apple.com/machine-learning/models/),
+                  "download_link": "https://developer.apple.com/machine-learning/models/",
                   "demo_link": "https://github.com/tucan9389/ImageSegmentation-CoreML",
                   "reference_link": "https://github.com/tensorflow/models/tree/master/research/deeplab",
                   "type": "image"
@@ -289,7 +289,7 @@
             {
                   "name": "DepthPrediction",
                   "description": "Predict the depth from a single image.",
-                  "download_link": (https://developer.apple.com/machine-learning/models/),
+                  "download_link": "https://developer.apple.com/machine-learning/models/",
                   "demo_link": "https://github.com/tucan9389/DepthPrediction-CoreML",
                   "reference_link": "https://github.com/iro-cp/FCRN-DepthPrediction",
                   "type": "image"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->


## Model URL

https://github.com/iro-cp/FCRN-DepthPrediction

## Demo URL

https://github.com/tucan9389/DepthPrediction-CoreML

<img src="https://github.com/tucan9389/DepthPrediction-CoreML/raw/master/resource/IMG_0129.gif" width=320px>

## Descriptions

Predict the depth from a single image

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [x] Only one item is in this pull request
- [x] The model info contains all the required fields
- [x] The demo project is compilable
- [x] Has proper reference
