### PR TITLE
Link for Netron appeared to be inactive. https://netron.app

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ We've put up the largest collection of machine learning models in Core ML format
 
 If you've converted a Core ML model, feel free to submit a [pull request](https://github.com/likedan/Awesome-CoreML-Models/compare).
 
-Recently, we've included visualization tools. And here's one [Netron](https://lutzroeder.github.io/Netron).
+Recently, we've included visualization tools. And here's one [Netron](https://github.com/lutzroeder/netron).
 
 [![Awesome](https://cdn.rawgit.com/sindresorhus/awesome/d7305f38d29fed78fa85652e3a63e154dd8e8829/media/badge.svg)](https://github.com/sindresorhus/awesome)
 [![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](http://makeapullrequest.com)
@@ -78,7 +78,7 @@ Recently, we've included visualization tools. And here's one [Netron](https://lu
 
 # Visualization Tools
 *Tools that help visualize CoreML Models*
-* [Netron](https://lutzroeder.github.io/Netron)
+* [Netron](https://github.com/lutzroeder/netron)
 
 # Supported formats
 *List of model formats that could be converted to Core ML with examples*


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

The netron link no longer works. The new website is https://netron.app but I linked the repository instead. https://github.com/lutzroeder/netron

## Model URL
<!--- The model URL -->

## Demo URL
<!--- The demo URL -->

## Descriptions
<!--- Describe what your model do -->

## Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
- [ ] Only one item is in this pull request
- [ ] The model info contains all the required fields
- [ ] The demo project is compilable
- [ ] Has proper reference
