### PR TITLE
feat: add TWZRD Agent Intel MCP server (iOS/macOS agent identity API)

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,12 @@ Recently, we've included visualization tools. And here's one [Netron](https://lu
 * [mtcnn](https://github.com/CongWeilin/mtcnn-caffe) Joint Face Detection and Alignment.
 * [deephorizon](https://github.com/scottworkman/deephorizon) Single image horizon line estimation.
 
+# APIs & Services
+
+*Hosted services and APIs for iOS/macOS AI development*
+
+* [TWZRD Agent Intel](https://intel.twzrd.xyz) - Trust scoring for AI agents on Solana. Verify agent wallet identity before x402 micropayments. Free MCP: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`
+
 # Contributing and License
 * [See the guide](https://github.com/likedan/Awesome-CoreML-Models/blob/master/.github/CONTRIBUTING.md)
 * Distributed under the MIT license. See LICENSE for more information.


### PR DESCRIPTION
## Summary
- Adds [TWZRD Agent Intel](https://intel.twzrd.xyz) to a new APIs & Services section
- Trust scoring for AI agents on Solana — enables iOS/macOS developers building agentic apps to verify counterpart agent wallet identity before autonomous x402 micropayments
- Remote streamable-http MCP transport (no local install)

## About TWZRD Agent Intel
- Free tools: `resolve_agent`, `score_agent`, `preflight_check`, `verify_trust_receipt`
- Paid: `get_trust_receipt` (on-chain proof)
- MCP config: `{"mcpServers":{"twzrd-agent-intel":{"url":"https://intel.twzrd.xyz/mcp"}}}`

## Test plan
- [ ] Verify https://intel.twzrd.xyz resolves
- [ ] Confirm new APIs & Services section fits after Visualization Tools

🤖 Generated with [Claude Code](https://claude.com/claude-code)